### PR TITLE
Remove Google Fonts from FAZ page

### DIFF
--- a/faz.html
+++ b/faz.html
@@ -18,11 +18,6 @@
 	<link rel="shortcut icon" href="icons/favicon.png">
 	<link rel="manifest" href="manifest.json">
 	<link rel="stylesheet" href="css/style.css">
-	<link rel="preconnect" href="https://fonts.googleapis.com">
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-	<link
-		href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&display=swap"
-		rel="stylesheet">
 	<script defer src="https://cloud.umami.is/script.js"
 		data-website-id="2392a451-203c-4d8a-a4f5-bd7d06f832af"></script>
 </head>


### PR DESCRIPTION
## Summary
- remove Google Fonts preconnect and stylesheet links from `faz.html`, relying on the local FAZ theme fonts

## Testing
- `node -e "const fs=require('fs');const css=fs.readFileSync('css/style.css','utf8');console.log(css.includes('DV Source Sans 3'));"`
- `deno fmt faz.html css/style.css js/app.js js/words.js service-worker.js index.html manifest.json README.md` *(fails: command not found)*
- `curl -fsSL https://deno.land/install.sh | sh -s -- -y` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6366982a48331898ca0d762f7648d