### PR TITLE
refactor: separate brand colors

### DIFF
--- a/css/core.css
+++ b/css/core.css
@@ -4,15 +4,15 @@
     --modal-bg-color: #444;
     --main-font-color: #333;
     --highlight-font-color: #eee;
-    --color-correct: rgb(106, 170, 100);
-    --color-present: rgb(201, 180, 88);
-    --color-absent: rgb(120, 124, 126);
-    --border-standard: 2px solid #ccc;
-    --border-highlight: 2px solid #999;
-    --border-active: 2px dashed #999;
+    --color-correct: #000;
+    --color-present: #000;
+    --color-absent: #000;
+    --border-standard: 2px solid #000;
+    --border-highlight: 2px solid #000;
+    --border-active: 2px dashed #000;
     --key-font-color: #333;
-    --key-highlight-bg-color: #aaa;
-    --key-bg-color: #cdcdcd;
+    --key-highlight-bg-color: #000;
+    --key-bg-color: #000;
     --animation-delay: 0.15s;
 }
 

--- a/css/theme-wortsel.css
+++ b/css/theme-wortsel.css
@@ -1,0 +1,10 @@
+:root {
+    --color-correct: rgb(106, 170, 100);
+    --color-present: rgb(201, 180, 88);
+    --color-absent: rgb(120, 124, 126);
+    --border-standard: 2px solid #ccc;
+    --border-highlight: 2px solid #999;
+    --border-active: 2px dashed #999;
+    --key-highlight-bg-color: #aaa;
+    --key-bg-color: #cdcdcd;
+}

--- a/faz.html
+++ b/faz.html
@@ -16,8 +16,9 @@
 
 	<link rel="apple-touch-icon" href="icons/180x180.png" />
 	<link rel="shortcut icon" href="icons/favicon.png">
-	<link rel="manifest" href="manifest.json">
-	<link rel="stylesheet" href="css/style.css">
+        <link rel="manifest" href="manifest.json">
+        <link rel="stylesheet" href="css/core.css">
+        <link rel="stylesheet" href="css/theme-wortsel.css">
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link

--- a/index.html
+++ b/index.html
@@ -16,8 +16,9 @@
 
 	<link rel="apple-touch-icon" href="icons/180x180.png" />
 	<link rel="shortcut icon" href="icons/favicon.png">
-	<link rel="manifest" href="manifest.json">
-	<link rel="stylesheet" href="css/style.css">
+        <link rel="manifest" href="manifest.json">
+        <link rel="stylesheet" href="css/core.css">
+        <link rel="stylesheet" href="css/theme-wortsel.css">
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link


### PR DESCRIPTION
## Summary
- move styling to `css/core.css` with neutral placeholder colors
- add `css/theme-wortsel.css` to restore Wortsel brand palette
- update HTML to include new stylesheets

## Testing
- `deno fmt css/core.css css/theme-wortsel.css index.html faz.html` *(fails: command not found)*
- `deno lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a637f78e948331a072f5d839b3e935