### PR TITLE
Refactor typography variables for scalable headings

### DIFF
--- a/css/core.css
+++ b/css/core.css
@@ -82,10 +82,16 @@
     margin-bottom: 2vmin;
   }
 
-  header img,
-  aside img {
+  header img {
     width: 4vmin;
     height: 4vmin;
+    cursor: pointer;
+    filter: var(--header-img-filter);
+  }
+
+  aside img {
+    width: 3vmin;
+    height: 3vmin;
     cursor: pointer;
     filter: var(--header-img-filter);
   }

--- a/css/core.css
+++ b/css/core.css
@@ -19,7 +19,12 @@
     --key-bg-color: #cdcdcd;
     --key-width: 7.5%;
     --font-family: sans-serif;
-    --base-font-size: 2.5vmin;
+    --root-font-size: 16px;
+    --scale-h1: 2;
+    --scale-h2: 1.5;
+    --scale-h3: 1.25;
+    --scale-credit: 0.75;
+    --scale-modal: 1;
     --header-img-filter: none;
     --modal-font-color: #ddd;
     --backdrop-bg-color: hsla(0,0%,0%,0.2);
@@ -37,6 +42,7 @@
     -webkit-tap-highlight-color: rgba(0,0,0,0);
     margin: 0;
     padding: 0;
+    font-size: var(--root-font-size);
   }
 
   body {
@@ -48,7 +54,6 @@
     padding: 0;
     color: var(--main-font-color);
     font-family: var(--font-family);
-    font-size: var(--base-font-size);
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
@@ -91,7 +96,7 @@
 
   h1 {
     text-transform: uppercase;
-    font-size: 5vmin;
+    font-size: calc(1rem * var(--scale-h1));
     font-weight: 500;
     margin: 1vmin 4vmin;
     cursor: pointer;
@@ -248,18 +253,18 @@
     background-color: var(--modal-bg-color);
     color: var(--modal-font-color);
     border-radius: 0.5vmin;
-    font-size: 2vmin;
+    font-size: calc(1rem * var(--scale-modal));
     text-align: center;
   }
 
   h2 {
-    font-size: 3vmin;
+    font-size: calc(1rem * var(--scale-h2));
     font-weight: 600;
     margin: 0;
   }
 
   h3 {
-    font-size: 2.5vmin;
+    font-size: calc(1rem * var(--scale-h3));
     font-weight: 600;
   }
 
@@ -321,14 +326,10 @@
   }
 
   .credit {
-    font-size: 2vmin;
+    font-size: calc(1rem * var(--scale-credit));
   }
 
   @media only screen and (max-width: 450px) and (orientation: portrait) {
-    body {
-      font-size: 4vmin;
-    }
-
     header {
       width: 88vw;
     }
@@ -336,10 +337,6 @@
     header img {
       width: 6vmin;
       height: 6vmin;
-    }
-
-    h1 {
-      font-size: 8vmin;
     }
 
     .letter {
@@ -360,12 +357,10 @@
     }
 
     h2 {
-      font-size: 5vmin;
       margin: 0;
     }
 
     h3 {
-      font-size: 4vmin;
       margin: 0 0 2vmin 0;
     }
 
@@ -386,13 +381,7 @@
       padding: 3vmin;
     }
 
-    .modal {
-      font-size: 4vmin;
-    }
-
-    .credit {
-      font-size: 3vmin;
-    }
+    /* modal and credit inherit font sizes */
 
     .option {
       padding: 0 6vmin;
@@ -464,3 +453,4 @@
     100% { transform: translateX(0vmin); }
   }
 }
+

--- a/css/theme-faz.css
+++ b/css/theme-faz.css
@@ -42,7 +42,7 @@
     --scale-h1: 2.5;
     --scale-h2: 1.75;
     --scale-h3: 1.5;
-    --scale-credit: 0.875;
+    --scale-credit: 1;
     --scale-modal: 1.125;
     --header-img-filter: none;
     --modal-font-color: #ddd;

--- a/css/theme-faz.css
+++ b/css/theme-faz.css
@@ -38,7 +38,12 @@
     --key-bg-color: #c6c6c6;
     --key-width: 7.8%;
     --font-family: "DV Source Sans 3", Helvetica, Arial, sans-serif;
-    --base-font-size: 16px;
+    --root-font-size: 16px;
+    --scale-h1: 2.5;
+    --scale-h2: 1.75;
+    --scale-h3: 1.5;
+    --scale-credit: 0.875;
+    --scale-modal: 1.125;
     --header-img-filter: none;
     --modal-font-color: #ddd;
     --backdrop-bg-color: hsla(0, 0%, 0%, 0.2);
@@ -109,8 +114,5 @@
       padding: 3vmin 6vmin;
     }
 
-    .input {
-      font-size: 4vmin;
-    }
   }
 }

--- a/css/theme-wortsel.css
+++ b/css/theme-wortsel.css
@@ -16,7 +16,12 @@
     --key-highlight-bg-color: #aaa;
     --key-bg-color: #cdcdcd;
     --font-family: 'Work Sans', sans-serif;
-    --base-font-size: 2.5vmin;
+    --root-font-size: clamp(15px, 1.2vw + 12px, 18px);
+    --scale-h1: 2.4;
+    --scale-h2: 1.7;
+    --scale-h3: 1.3;
+    --scale-credit: 0.9;
+    --scale-modal: 1.1;
     --header-img-filter: none;
     --modal-font-color: #ddd;
     --backdrop-bg-color: hsla(0,0%,0%,0.2);


### PR DESCRIPTION
## Summary
- centralize typography with `--root-font-size` and scale factors
- apply scalable sizes to headings, modal, and credit text
- theme files define fluid or fixed root font sizes and scale values

## Testing
- `deno fmt css/core.css css/theme-faz.css css/theme-wortsel.css` *(fails: command not found)*
- `curl -fsSL https://deno.land/x/install/install.sh | sh` *(fails: 403)*
- `deno lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d93c8ec08331973cdbc72feb0289