### PR TITLE
Use AbortController for input listeners

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -516,22 +516,24 @@ function resetGame() {
 }
 
 // Manage keyboard input listeners (to disable input after game end)
-let listenersActive = false;
+let inputController;
 function addInputListeners() {
-	if (listenersActive) return;
-	document.addEventListener("keyup", typeKey, false);
-	document.addEventListener("keydown", handleVirtualKeyFeedback);
-	document.addEventListener("keyup", handleVirtualKeyFeedback);
-	keyboardElement?.addEventListener("click", typeKey, false);
-	listenersActive = true;
+		inputController = new AbortController();
+		document.addEventListener("keyup", typeKey, {
+				signal: inputController.signal,
+		});
+		document.addEventListener("keydown", handleVirtualKeyFeedback, {
+				signal: inputController.signal,
+		});
+		document.addEventListener("keyup", handleVirtualKeyFeedback, {
+				signal: inputController.signal,
+		});
+		keyboardElement?.addEventListener("click", typeKey, {
+				signal: inputController.signal,
+		});
 }
 function removeInputListeners() {
-	if (!listenersActive) return;
-	document.removeEventListener("keyup", typeKey, false);
-	document.removeEventListener("keydown", handleVirtualKeyFeedback);
-	document.removeEventListener("keyup", handleVirtualKeyFeedback);
-	keyboardElement?.removeEventListener("click", typeKey, false);
-	listenersActive = false;
+		inputController?.abort();
 }
 
 /**

--- a/js/app.js
+++ b/js/app.js
@@ -518,22 +518,16 @@ function resetGame() {
 // Manage keyboard input listeners (to disable input after game end)
 let inputController;
 function addInputListeners() {
-		inputController = new AbortController();
-		document.addEventListener("keyup", typeKey, {
-				signal: inputController.signal,
-		});
-		document.addEventListener("keydown", handleVirtualKeyFeedback, {
-				signal: inputController.signal,
-		});
-		document.addEventListener("keyup", handleVirtualKeyFeedback, {
-				signal: inputController.signal,
-		});
-		keyboardElement?.addEventListener("click", typeKey, {
-				signal: inputController.signal,
-		});
+	inputController = new AbortController();
+	const { signal } = inputController;
+	document.addEventListener("keyup", typeKey, { signal });
+	document.addEventListener("keydown", handleVirtualKeyFeedback, { signal });
+	document.addEventListener("keyup", handleVirtualKeyFeedback, { signal });
+	keyboardElement?.addEventListener("click", typeKey, { signal });
 }
 function removeInputListeners() {
-		inputController?.abort();
+	inputController?.abort();
+	inputController = null;
 }
 
 /**
@@ -546,11 +540,11 @@ function initGame() {
 		localStorage.setItem("wortsel_firstVisit", JSON.stringify(false));
 	}
 
-	const gameBoard = document.querySelector("main");
-
 	document.addEventListener("touchstart", () => {}, false);
-	gameBoard.addEventListener("animationend", stopAnyAnimation, false);
 	addInputListeners();
+
+	const gameBoard = document.querySelector("main");
+	gameBoard.addEventListener("animationend", stopAnyAnimation, false);
 	gameBoard.addEventListener("click", setLetterIndex, false);
 	if (headlineElement) headlineElement.addEventListener("click", resetGame, false);
 


### PR DESCRIPTION
## Summary
- Use a module-level `AbortController` for keyboard and click listeners
- Abort the controller to remove listeners reliably, including on iOS
- Re-add input listeners on game reset to create a fresh controller

## Testing
- `deno fmt js/app.js` *(fails: command not found)*
- `deno lint js/app.js` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa19529db88331ab76816341e3bf54