### PR TITLE
feat: allow puzzle selection via URL index

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ FAZ). All brand assets in such deployments belong to their respective owners.
   internet connection.
 - **Responsive Design**: Optimized for both desktop and mobile devices.
 - **Settings Persistence**: Last game options are stored in `localStorage`.
+- **Shareable Puzzles**: Append `?word=<index>` to the URL to set a specific solution,
+  useful for custom challenges.
 - **Hard Mode (strict)**: Once enabled, green letters are locked in place, gray keys cannot be used
   again, and yellow letters may not be placed again at the same position. This stricter variant
   reduces trial‑and‑error and forces more deduction, going beyond Wordle’s hard mode.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ FAZ). All brand assets in such deployments belong to their respective owners.
   internet connection.
 - **Responsive Design**: Optimized for both desktop and mobile devices.
 - **Settings Persistence**: Last game options are stored in `localStorage`.
-- **Shareable Puzzles**: Append `?word=<index>` to the URL to set a specific solution,
-  useful for custom challenges.
+- **Shareable Puzzles**: Append `?idx=<index>` to the URL to set a specific solution,
+  useful for custom challenges. The parameter is removed after loading so refreshes
+  start a random puzzle again.
 - **Hard Mode (strict)**: Once enabled, green letters are locked in place, gray keys cannot be used
   again, and yellow letters may not be placed again at the same position. This stricter variant
   reduces trial‑and‑error and forces more deduction, going beyond Wordle’s hard mode.

--- a/js/app.js
+++ b/js/app.js
@@ -38,26 +38,23 @@ const firstVisit = JSON.parse(
 const wordList = [...curatedWords, ...additionalWords];
 const wordSet = new Set(wordList.map((w) => w.toLowerCase()));
 let solution = curatedWords[getRandomInteger(0, curatedWords.length - 1)]
-        .toLowerCase();
+	.toLowerCase();
 
 // Allow overriding the solution via a URL parameter (?idx=<index>)
-const currentUrl = new URL(globalThis.location?.href ?? "https://example.com");
+const currentUrl = new URL(globalThis.location?.href);
 const idxParam = currentUrl.searchParams.get("idx");
 let viaChallenge = false;
-if (idxParam !== null) {
-        if (/^\d+$/.test(idxParam)) {
-                const idx = Number(idxParam);
-                if (idx >= 0 && idx < curatedWords.length) {
-                        solution = curatedWords[idx].toLowerCase();
-                        viaChallenge = true;
-                        currentUrl.searchParams.delete("idx");
-                        history.replaceState(null, "", currentUrl);
-                } else {
-                        console.warn(`Invalid puzzle index: ${idxParam}`);
-                }
-        } else {
-                console.warn(`Invalid puzzle index: ${idxParam}`);
-        }
+
+if (idxParam) {
+	const idx = parseInt(idxParam, 10);
+	if (idx >= 0 && idx < curatedWords.length) {
+		solution = curatedWords[idx].toLowerCase();
+		viaChallenge = true;
+		currentUrl.searchParams.delete("idx");
+		history.replaceState(null, "", currentUrl);
+	} else {
+		console.warn(`Invalid puzzle index: ${idxParam}`);
+	}
 }
 
 // Hard mode state
@@ -441,14 +438,14 @@ function checkEndCondition() {
 		isGameOver = true;
 		removeInputListeners();
 
-                if (analyticsPayload) {
-                        globalThis.umami?.track("Wortsel", {
-                                ...analyticsPayload,
-                                usedDictionary: wholeWordsCheckbox.checked,
-                                activatedHardMode: hardModeCheckbox.checked,
-                                viaChallenge,
-                        });
-                }
+		if (analyticsPayload) {
+			globalThis.umami?.track("Wortsel", {
+				...analyticsPayload,
+				usedDictionary: wholeWordsCheckbox.checked,
+				activatedHardMode: hardModeCheckbox.checked,
+				viaChallenge: viaChallenge,
+			});
+		}
 
 		postCommunityStats({
 			solution,

--- a/js/app.js
+++ b/js/app.js
@@ -40,6 +40,16 @@ const wordSet = new Set(wordList.map((w) => w.toLowerCase()));
 let solution = curatedWords[getRandomInteger(0, curatedWords.length - 1)]
 	.toLowerCase();
 
+// Allow overriding the solution via a URL parameter (?word=<index>)
+const urlParams = new URLSearchParams(globalThis.location?.search || "");
+const wordIndex = urlParams.get("word");
+if (wordIndex !== null) {
+	const idx = parseInt(wordIndex, 10);
+	if (!Number.isNaN(idx) && idx >= 0 && idx < curatedWords.length) {
+		solution = curatedWords[idx].toLowerCase();
+	}
+}
+
 // Hard mode state
 let lockedLetters = [null, null, null, null, null]; // fixed, correct letters carried over
 // In hard mode, prevent reusing yellow letters at the same position


### PR DESCRIPTION
## Summary
- allow overriding the solution with `?word=<index>` URL param
- document new shareable puzzle parameter in README

## Testing
- `deno fmt js/app.js README.md` *(fails: command not found)*
- `deno lint js/app.js README.md` *(fails: command not found)*
- `curl -fsSL https://deno.land/install.sh | sh` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68b84c3445a4833196d7e608c6dd6e5a